### PR TITLE
Fix: vite config now gets copied to new repo

### DIFF
--- a/repoGen.sh
+++ b/repoGen.sh
@@ -69,6 +69,7 @@ while getopts "j:b:t:v:" opt; do
       cp $HOME/repoGen/favicon.ico favicon.ico
       cp $HOME/repoGen/.prettierrc.toml .prettierrc.toml
       cp $HOME/repoGen/typescript/.eslintrc.json .eslintrc.json
+      cp $HOME/repoGen/typescript/vite.config.js vite.config.js 
       cp $HOME/repoGen/readme_template.md README.md
 
       ## install eslint and prettier


### PR DESCRIPTION
When generating a vite project, the script will copy a vite.config.js file to the root of the generated repo